### PR TITLE
Fix create project command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Use Composer to bootstrap your project.
 1. Clone and install deps:
 
     ```bash
-    composer create-project wp-oop/plugin-boilerplate my_plugin
+    composer create-project wp-oop/plugin-boilerplate my_plugin --stability=dev
     ```
    
    Here, `my_plugin` is the name of the project folder. Should correspond


### PR DESCRIPTION
Addresses https://github.com/wp-oop/plugin-boilerplate/issues/4

Add stability flag `dev` to the `create-project` command example. Without that command, an error was triggered. It happened because default stability for the new project is `stable`, but `plugin-boilerplate` has stability `dev` now.