### PR TITLE
Make shell scripts executable

### DIFF
--- a/docker/Dockerfile_wp
+++ b/docker/Dockerfile_wp
@@ -50,6 +50,8 @@ ARG WP_DOMAIN
 COPY docker/wp-entrypoint.sh /usr/local/bin
 COPY docker/wait-for-it.sh /usr/local/bin
 
+RUN chmod +x /usr/local/bin/wp-entrypoint.sh /usr/local/bin/wait-for-it.sh
+
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /usr/local/bin/wp


### PR DESCRIPTION
Addresses https://github.com/wp-oop/plugin-boilerplate/issues/5

Without that, an error was thrown:
`ERROR: for me_plugin_wp_dev  Cannot start service wp_dev: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "./wp-entrypoint.sh": stat ./wp-entrypoint.sh: no such file or directory: unknown`