### PR TITLE
Explicitly use Composer v1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+        tools: composer:v1
 
     - name: Analysing source code
       run: find ./src/ ./inc/ ./tests/ -type f -name '*.php' -print0 | xargs -0 -L 1 -P 4 -- php -l


### PR DESCRIPTION
Cannot install deps from `composer.lock` generated by Composer v1 with Composer v2. This fixes the problem by making the env use Composer v1 explicitly.