### PR TITLE
Fix Composer Version

### DIFF
--- a/docker/Dockerfile_wp
+++ b/docker/Dockerfile_wp
@@ -10,7 +10,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 RUN apt-get update
 RUN apt-get install -y zip unzip curl git
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php composer-setup.php --install-dir=/usr/bin --filename=composer
+RUN php composer-setup.php --install-dir=/usr/bin --filename=composer --version=1.10.17
 RUN php -r "unlink('composer-setup.php');"
 
 WORKDIR ${BUILD_ROOT_PATH}


### PR DESCRIPTION
Composer v2 is now the latest stable, and this is what gets installed by default. But many packages, especially Composer plugins, rely on Composer API v1. This fixes the problem by installing Composer v1 inside the container.