### PR TITLE
Include only WP from vendor for psalm

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -33,11 +33,8 @@
     </projectFiles>
 
     <extraFiles>
-        <ignoreFiles>
-            <directory name="vendor/phpunit/php-code-coverage/tests"/>
-            <directory name="vendor/phpspec/prophecy"/>
-        </ignoreFiles>
-        <directory name="vendor" />
+        <directory name="vendor/johnpbloch/wordpress-core/wp-includes" />
+        <directory name="vendor/johnpbloch/wordpress-core/wp-admin/includes" />
     </extraFiles>
 
 


### PR DESCRIPTION
Psalm was crashing for me with a weird exception. After running with `--debug` found that it crashes when trying to parse its' own code in `vendor`. Tried psalm 3.x and 4.x.

I think we don't need to include everything from `vendor`, only the things that do not use the normal autoload.
Looks like in other projects we add only WP includes.