### PR TITLE
Fix errors reported by Psalm

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -33,7 +33,6 @@
       <path value="$PROJECT_DIR$/vendor/dhii/collections-interface" />
       <path value="$PROJECT_DIR$/vendor/dhii/package-interface" />
       <path value="$PROJECT_DIR$/vendor/dhii/validation-interface" />
-      <path value="$PROJECT_DIR$/vendor/dhii/containers" />
       <path value="$PROJECT_DIR$/vendor/dhii/versions" />
       <path value="$PROJECT_DIR$/vendor/dhii/stringable-interface" />
       <path value="$PROJECT_DIR$/vendor/symfony/service-contracts" />
@@ -68,6 +67,13 @@
       <path value="$PROJECT_DIR$/vendor/phpdocumentor/type-resolver" />
       <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-docblock" />
       <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-common" />
+      <path value="$PROJECT_DIR$/vendor/ocramius/package-versions" />
+      <path value="$PROJECT_DIR$/vendor/webmozart/glob" />
+      <path value="$PROJECT_DIR$/vendor/dhii/exception-interface" />
+      <path value="$PROJECT_DIR$/vendor/dhii/factory-interface" />
+      <path value="$PROJECT_DIR$/vendor/dhii/data-container-interface" />
+      <path value="$PROJECT_DIR$/vendor/php-stubs/wordpress-stubs" />
+      <path value="$PROJECT_DIR$/vendor/dhii/containers" />
     </include_path>
   </component>
   <component name="PhpInterpreters">

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -6,7 +6,6 @@
       <path value="$PROJECT_DIR$/vendor/dealerdirect/phpcodesniffer-composer-installer" />
       <path value="$PROJECT_DIR$/vendor/psr/container" />
       <path value="$PROJECT_DIR$/vendor/composer" />
-      <path value="$PROJECT_DIR$/vendor/johnpbloch/wordpress-core" />
       <path value="$PROJECT_DIR$/vendor/sebastian/version" />
       <path value="$PROJECT_DIR$/vendor/amphp/amp" />
       <path value="$PROJECT_DIR$/vendor/amphp/byte-stream" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="PhpCodeSniffer">
+    <phpcs_settings>
+      <phpcs_by_interpreter interpreter_id="41143493-fc09-4c8e-95b8-ee171ed1f0fd" tool_path="/app/vendor/bin/phpcs" timeout="30000" />
+    </phpcs_settings>
+  </component>
   <component name="PhpIncludePathManager">
     <include_path>
       <path value="$PROJECT_DIR$/vendor/container-interop/service-provider" />

--- a/.idea/plugin.iml
+++ b/.idea/plugin.iml
@@ -36,7 +36,6 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/dhii/collections-interface" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/dhii/package-interface" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/dhii/validation-interface" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/dhii/containers" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/dhii/versions" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/dhii/stringable-interface" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/service-contracts" />
@@ -71,6 +70,8 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpdocumentor/type-resolver" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-docblock" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-common" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/php-stubs/wordpress-stubs" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/dhii/containers" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/plugin.iml
+++ b/.idea/plugin.iml
@@ -9,7 +9,6 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/dealerdirect/phpcodesniffer-composer-installer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/psr/container" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/johnpbloch/wordpress-core" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/version" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/amphp/amp" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/amphp/byte-stream" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Fixed
+- Errors in local modules (#17).
+
+### Changed
+- Depend on WP stubs instead of WP itself (#17).
+- Actually use the stubs in Psalm (#17).
+
+### Added
+- Local modules are now scanned by Psalm (#17).
+- PHPStorm will now use PHPCS via remote interpreter (#17).
 
 ## [0.2.0-alpha1] - 2021-03-10
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
-    "johnpbloch/wordpress-core": "^5.0@stable",
     "vimeo/psalm": "^3.11.7 | ^4.0",
     "slevomat/coding-standard": "^6.0",
-    "webmozart/path-util": "^2.3@stable"
+    "webmozart/path-util": "^2.3@stable",
+    "php-stubs/wordpress-stubs": "^5.0@stable"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "238731453f941d4021408cdeeb844076",
+    "content-hash": "5652163a69ce6a4f3d326704209e702a",
     "packages": [
         {
             "name": "container-interop/service-provider",
@@ -103,12 +103,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/containers.git",
-                "reference": "eaa5601e439a6f8bce998ab082bc7b90e6391c69"
+                "reference": "b76c73d172255eddb9d6e2a3a9ed2306c8b42563"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/containers/zipball/eaa5601e439a6f8bce998ab082bc7b90e6391c69",
-                "reference": "eaa5601e439a6f8bce998ab082bc7b90e6391c69",
+                "url": "https://api.github.com/repos/Dhii/containers/zipball/b76c73d172255eddb9d6e2a3a9ed2306c8b42563",
+                "reference": "b76c73d172255eddb9d6e2a3a9ed2306c8b42563",
                 "shasum": ""
             },
             "require": {
@@ -154,9 +154,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Dhii/containers/issues",
-                "source": "https://github.com/Dhii/containers/tree/develop"
+                "source": "https://github.com/Dhii/containers/tree/v0.1.4-alpha2"
             },
-            "time": "2021-03-10T08:53:06+00:00"
+            "time": "2021-03-10T08:54:31+00:00"
         },
         {
             "name": "dhii/human-readable-interface",
@@ -1386,54 +1386,6 @@
             "time": "2021-02-22T14:02:09+00:00"
         },
         {
-            "name": "johnpbloch/wordpress-core",
-            "version": "5.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "8b057056692ca196aaa7a7ddd915f29426922c6d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/8b057056692ca196aaa7a7ddd915f29426922c6d",
-                "reference": "8b057056692ca196aaa7a7ddd915f29426922c6d",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": ">=5.6.20"
-            },
-            "provide": {
-                "wordpress/core-implementation": "5.7.0"
-            },
-            "type": "wordpress-core",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "WordPress Community",
-                    "homepage": "https://wordpress.org/about/"
-                }
-            ],
-            "description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
-            "homepage": "https://wordpress.org/",
-            "keywords": [
-                "blog",
-                "cms",
-                "wordpress"
-            ],
-            "support": {
-                "forum": "https://wordpress.org/support/",
-                "irc": "irc://irc.freenode.net/wordpress",
-                "issues": "https://core.trac.wordpress.org/",
-                "source": "https://core.trac.wordpress.org/browser",
-                "wiki": "https://codex.wordpress.org/"
-            },
-            "time": "2021-03-09T20:32:23+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.x-dev",
             "source": {
@@ -1763,6 +1715,50 @@
                 "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
             "time": "2021-02-23T14:00:09+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "69baf30e7c92f149526da950a68222af05f7bc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/69baf30e7c92f149526da950a68222af05f7bc67",
+                "reference": "69baf30e7c92f149526da950a68222af05f7bc67",
+                "shasum": ""
+            },
+            "replace": {
+                "giacocorsiglia/wordpress-stubs": "*"
+            },
+            "require-dev": {
+                "giacocorsiglia/stubs-generator": "^0.5.0",
+                "php": "~7.1"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.7.0"
+            },
+            "time": "2021-03-10T10:29:23+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4274,8 +4270,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "johnpbloch/wordpress-core": 0,
-        "webmozart/path-util": 0
+        "webmozart/path-util": 0,
+        "php-stubs/wordpress-stubs": 0
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/modules.local/core/module.php
+++ b/modules.local/core/module.php
@@ -8,7 +8,9 @@ return function (string $rootDir, string $mainFile): ModuleInterface {
     $rootDir = dirname($mainFile);
     $moduleDir = dirname(__FILE__);
     $moduleIncDir = "$moduleDir/inc";
+    /** @psalm-suppress UnresolvableInclude */
     $factories = (require "$moduleIncDir/factories.php")($rootDir, $mainFile);
+    /** @psalm-suppress UnresolvableInclude */
     $extensions = (require "$moduleIncDir/extensions.php")($rootDir, $mainFile);
     $provider = new ServiceProvider($factories, $extensions);
     $module = new Module($provider);

--- a/modules.local/core/src/FilePathPluginFactory.php
+++ b/modules.local/core/src/FilePathPluginFactory.php
@@ -12,6 +12,9 @@ use UnexpectedValueException;
 use WpOop\WordPress\Plugin\FilePathPluginFactoryInterface;
 use WpOop\WordPress\Plugin\PluginInterface;
 
+use function plugin_basename;
+use function get_plugin_data;
+
 /**
  * Creates a plugin from plugin basename.
  */

--- a/modules.local/core/src/Plugin.php
+++ b/modules.local/core/src/Plugin.php
@@ -44,11 +44,6 @@ class Plugin implements PluginInterface
     protected $textDomain;
 
     /**
-     * @var string
-     */
-    protected $slug;
-
-    /**
      * @var VersionInterface
      */
     protected $minPhpVersion;

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -25,12 +25,12 @@
 >
     <projectFiles>
         <directory name="src"/>
+        <directory name="modules.local"/>
     </projectFiles>
 
-    <extraFiles>
-        <directory name="vendor/johnpbloch/wordpress-core/wp-includes" />
-        <directory name="vendor/johnpbloch/wordpress-core/wp-admin/includes" />
-    </extraFiles>
+    <stubs>
+        <file name="vendor/php-stubs/wordpress-stubs/wordpress-stubs.php" />
+    </stubs>
 
 
     <issueHandlers>


### PR DESCRIPTION
- Remove unused property.
- Add WP stubs to Psalm.
- Use WP stubs instead of WP itself.
- Suppress everywhere else.
- Add PHCS to PHPStorm via remote interpreter.