### PR TITLE
Allow superuser for Composer during vendor installation

### DIFF
--- a/docker/Dockerfile_wp
+++ b/docker/Dockerfile_wp
@@ -82,7 +82,7 @@ FROM build as vendor-dev
 ARG BUILD_ROOT_PATH
 
 WORKDIR ${BUILD_ROOT_PATH}
-RUN make build
+RUN COMPOSER_ALLOW_SUPERUSER=1 make build
 
 
 # WordPress for development


### PR DESCRIPTION
Otherwise, the build step that installs dependencies may fail, because Docker provisions as super-user.