### PR TITLE
Do not translate plugin data when creating instance

### DIFF
--- a/src/FilePathPluginFactory.php
+++ b/src/FilePathPluginFactory.php
@@ -45,7 +45,7 @@ class FilePathPluginFactory implements FilePathPluginFactoryInterface
             );
         }
 
-        $pluginData = get_plugin_data($filePath);
+        $pluginData = get_plugin_data($filePath, true, false);
         if (empty($pluginData)) {
             throw new UnexpectedValueException(
                 sprintf(


### PR DESCRIPTION
When retrieving plugin data, translation is no longer used. This used to cause the plugin's text domain to be loaded. It caused weird situations when working with and overriding WP i18n. Example:

You need to override the translation file using `override_load_textdomain`. For this, you need the name of the text domain to override translations for, so as not to affect other plugins/themes. You decide to retrieve the plugin's text domain by using the plugin created by this plugin factory. This loaded the text domain, which caused your override to be bypassed: you are still in the process of registering it.

Now, the factory no longer causes the plugin text domain to load, and you can safely load it later at a time convenient for you.